### PR TITLE
security: bump lodash to 4.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6872,9 +6872,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
       "dev": true
     },
     "node_modules/lodash._reinterpolate": {
@@ -15617,9 +15617,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
       "dev": true
     },
     "lodash._reinterpolate": {


### PR DESCRIPTION
## Summary

Patches a **medium severity** prototype pollution vulnerability in `lodash` via array path bypass in `_.unset` and `_.omit`. First patched version is `4.18.0`.

Lockfile-only change to the root `package-lock.json`. `lodash` is a transitive dev dependency (used by conventional-changelog tooling and similar). Only the single hoisted `lodash` entry is touched.

Note: the `lodash.*` sibling packages (`lodash.debounce`, `lodash.template`, `lodash.templatesettings`, etc.) are **separate published packages**, not affected by this advisory, and are intentionally left at their current versions.

## Closes

- Dependabot alert [#139](https://github.com/stephen-zhao/sophii.co/security/dependabot/139)

## Test plan

- [x] CI passes
- [x] `npm install` produces no integrity mismatches
- [x] No runtime impact expected (dev-only dependency)