### PR TITLE
fix(tests): point production-test.html files at correct CDN filenames

### DIFF
--- a/packages/avoidance/test/production-test.html
+++ b/packages/avoidance/test/production-test.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="https://cdn.jsdelivr.net/npm/@zhaostephen/avoidance/dist/avoidance.var.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@zhaostephen/avoidance/dist/avoidance.min.js"></script>
     <style>
       .containers-grid-shell {
         padding: 10px;

--- a/packages/draggamil/test/production-test.html
+++ b/packages/draggamil/test/production-test.html
@@ -29,7 +29,7 @@
       <div class="draggable"><div id="drag-me-sticker">Drag Me!!</div></div>
       <div class="draggable"></div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/@zhaostephen/draggamil/dist/draggamil.var.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@zhaostephen/draggamil/dist/draggamil.min.js"></script>
     <script>
       (function() {
         Draggamil(".container", ".draggable");


### PR DESCRIPTION
## Summary

Both production-test pages load JS from jsDelivr, but the URLs reference `<pkg>.var.min.js` files that the published npm packages never shipped. The rollup configs only build UMD `.js` and `.min.js`, so the CDN returns 404 and the library global (`Draggamil` / `Avoidance`) is never defined. The demo IIFE then silently throws and nothing on the page wires up.

Discovered while visually inspecting `packages/draggamil/test/production-test.html` locally - draggable boxes wouldn't move because the script never loaded.

## Changes

- `packages/draggamil/test/production-test.html`: `draggamil.var.min.js` -> `draggamil.min.js`
- `packages/avoidance/test/production-test.html`: `avoidance.var.min.js` -> `avoidance.min.js`

Both replacements point at files that **do exist** on jsDelivr (verified `HTTP/2 200`).

## Test plan

- [x] Open `packages/draggamil/test/production-test.html` in a browser, drag the red boxes around the goldenrod container
- [x] Open `packages/avoidance/test/production-test.html` in a browser, move the cursor through the particle containers and watch the particles avoid it
- [x] DevTools Network tab shows the new URLs returning 200, not 404