### PR TITLE
chore(deps): replace rollup-plugin-terser with @rollup/plugin-terser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2218,6 +2218,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -3292,6 +3303,65 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-terser/node_modules/serialize-javascript": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-terser/node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -3635,6 +3705,19 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/add-stream": {
@@ -6476,21 +6559,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8641,16 +8709,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
@@ -9088,23 +9146,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-terser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-6.1.0.tgz",
-      "integrity": "sha512-4fB3M9nuoWxrwm39habpd4hvrbrde2W2GG4zEGPQg1YITNkM3Tqur5jSuXlWNzbv/2aMLJ+dZJaySc3GCD8oDw==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "jest-worker": "^26.0.0",
-        "serialize-javascript": "^3.0.0",
-        "terser": "^4.7.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0"
-      }
-    },
     "node_modules/run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -9164,16 +9205,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shebang-command": {
@@ -9243,6 +9274,16 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smob": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+      "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/smol-toml": {
@@ -9529,31 +9570,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/terser": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/text-extensions": {
       "version": "1.9.0",
@@ -10154,8 +10170,8 @@
         "@rollup/plugin-babel": "^5.0.4",
         "@rollup/plugin-commonjs": "^13.0.0",
         "@rollup/plugin-node-resolve": "^8.1.0",
+        "@rollup/plugin-terser": "^1.0.0",
         "rollup": "^2.18.1",
-        "rollup-plugin-terser": "^6.1.0",
         "typescript": "^3.9.5"
       }
     },
@@ -10197,8 +10213,8 @@
         "@rollup/plugin-babel": "^5.0.4",
         "@rollup/plugin-commonjs": "^13.0.0",
         "@rollup/plugin-node-resolve": "^8.1.0",
+        "@rollup/plugin-terser": "^1.0.0",
         "rollup": "^2.18.1",
-        "rollup-plugin-terser": "^6.1.0",
         "typescript": "^3.9.5"
       }
     },

--- a/packages/avoidance/package.json
+++ b/packages/avoidance/package.json
@@ -34,7 +34,7 @@
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.1.0",
     "rollup": "^2.18.1",
-    "rollup-plugin-terser": "^6.1.0",
+    "@rollup/plugin-terser": "^1.0.0",
     "typescript": "^3.9.5"
   },
   "scripts": {

--- a/packages/avoidance/rollup.config.js
+++ b/packages/avoidance/rollup.config.js
@@ -2,7 +2,7 @@
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import pkg from './package.json';
 
 // Variables

--- a/packages/draggamil/package-lock.json
+++ b/packages/draggamil/package-lock.json
@@ -16,8 +16,8 @@
         "@rollup/plugin-babel": "^5.0.4",
         "@rollup/plugin-commonjs": "^13.0.0",
         "@rollup/plugin-node-resolve": "^8.1.0",
+        "@rollup/plugin-terser": "^1.0.0",
         "rollup": "^2.18.1",
-        "rollup-plugin-terser": "^6.1.0",
         "typescript": "^3.9.5"
       }
     },
@@ -1687,6 +1687,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1781,6 +1792,65 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-terser/node_modules/serialize-javascript": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-terser/node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -1824,6 +1894,19 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/anymatch": {
@@ -2266,16 +2349,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -2391,21 +2464,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2489,13 +2547,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -2590,16 +2641,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/readdirp": {
@@ -2712,44 +2753,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-terser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-6.1.0.tgz",
-      "integrity": "sha512-4fB3M9nuoWxrwm39habpd4hvrbrde2W2GG4zEGPQg1YITNkM3Tqur5jSuXlWNzbv/2aMLJ+dZJaySc3GCD8oDw==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "jest-worker": "^26.0.0",
-        "serialize-javascript": "^3.0.0",
-        "terser": "^4.7.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -2760,16 +2763,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -2778,6 +2771,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/smob": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+      "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/source-map": {
@@ -2809,19 +2812,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -2834,31 +2824,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/terser": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/packages/draggamil/package.json
+++ b/packages/draggamil/package.json
@@ -36,7 +36,7 @@
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.1.0",
     "rollup": "^2.18.1",
-    "rollup-plugin-terser": "^6.1.0",
+    "@rollup/plugin-terser": "^1.0.0",
     "typescript": "^3.9.5"
   },
   "scripts": {

--- a/packages/draggamil/rollup.config.js
+++ b/packages/draggamil/rollup.config.js
@@ -2,7 +2,7 @@
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import pkg from './package.json';
 
 // Variables


### PR DESCRIPTION
## Summary

Replaces the deprecated community plugin `rollup-plugin-terser@6.1.0` with the official `@rollup/plugin-terser@1.0.0` in both `packages/avoidance` and `packages/draggamil`.

`rollup-plugin-terser` was deprecated upstream and pulls in old versions of `serialize-javascript` that trigger four currently-open Dependabot alerts. The Rollup org publishes `@rollup/plugin-terser` as the maintained replacement; it's API-compatible aside from the import style.

## Changes

For each of `packages/avoidance` and `packages/draggamil`:

```diff
 // package.json
-    "rollup-plugin-terser": "^6.1.0",
+    "@rollup/plugin-terser": "^1.0.0",

 // rollup.config.js
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
```

Both lockfiles regenerated accordingly.

## Vulnerability impact

| | Before | After |
|---|---|---|
| Production runtime | 0 | 0 |
| `npm audit` total | 4 | **2** |

The 2 remaining (`nx`, `yaml`) are transitives of `lerna 9` itself, introduced when we bumped lerna in #33. Both moderate; addressing them would mean either bumping lerna again or dismissing.

Closes Dependabot alerts:
- [#121 serialize-javascript / root](https://github.com/stephen-zhao/sophii.co/security/dependabot/121)
- [#122 serialize-javascript / draggamil](https://github.com/stephen-zhao/sophii.co/security/dependabot/122)
- [#133 serialize-javascript / root](https://github.com/stephen-zhao/sophii.co/security/dependabot/133)
- [#134 serialize-javascript / draggamil](https://github.com/stephen-zhao/sophii.co/security/dependabot/134)

## What this PR does NOT do

`dist/` artifacts are intentionally **not** rebuilt. The security fix takes effect from the lockfile change alone (vulnerable `serialize-javascript` is no longer in the dep tree). A rebuild would refresh the published `.js` and `.min.js` files - which would be valid - but it's orthogonal to closing the alerts and would significantly inflate the PR diff with regenerated bundles. Worth doing as a separate follow-up before the next `npm publish`.

## Test plan

- [ ] `npm ci` from clean checkout
- [ ] `npm --workspace packages/avoidance run build` produces output without errors
- [ ] `npm --workspace packages/draggamil run build` same
- [ ] Demos at http://localhost:8080/ continue to work (using existing committed dist artifacts)
