### PR TITLE
security: bump tmp to 0.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "tmp": "^0.2.7"
+      },
       "devDependencies": {
         "lerna": "^9.0.7"
       }
@@ -7955,6 +7958,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/nx/node_modules/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/nx/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -9681,11 +9693,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
-      "dev": true,
-      "license": "MIT",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "engines": {
         "node": ">=14.14"
       }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   "private": true,
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "tmp": "^0.2.7"
+  }
 }


### PR DESCRIPTION
Automated security bump from the `weekly-gh-personal-security-maintenance` routine.

- Package: `tmp`
- Fixed version: `0.2.7`
- Manifest: `package-lock.json`
- Ecosystem: `npm`

Please review and merge if CI passes.